### PR TITLE
Fix: docker-compose MYSQL container "always" restart changed to "on-failure"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   database:
     image: mysql
     command: --event_scheduler=ON
-    restart: always
+    restart: on-failure
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
       MYSQL_DATABASE: mbot


### PR DESCRIPTION
Change restart to on-failure, atm it starts mysql from mbot when docker is on

https://docs.docker.com/engine/containers/start-containers-automatically/#use-a-restart-policy