### PR TITLE
deprecate: remove bot versioning being logged when bot is started

### DIFF
--- a/src/main/java/me/mbot/configuration/BotConfiguration.java
+++ b/src/main/java/me/mbot/configuration/BotConfiguration.java
@@ -54,7 +54,6 @@ public class BotConfiguration {
                     )
                     .build()
                     .awaitReady();
-            logger.info(Constants.getBotVersion());
             /*
             Assign roles to all members based on their xp amount when bot starts,
             normally not needed but good for double check,

--- a/src/main/java/me/mbot/configuration/Constants.java
+++ b/src/main/java/me/mbot/configuration/Constants.java
@@ -9,8 +9,7 @@ import java.util.List;
 import java.util.Properties;
 
 public class Constants {
-    private static String BOT_VERSION;
-    private static final Logger logger = LoggerFactory.getLogger(Constants.class);
+
     private static final String BOT_TOKEN = System.getenv("BOT_TOKEN");
     private static final String CHANNEL_LOG_ID = System.getenv("CHANNEL_LOG_ID");
     private static final String CHANNEL_DARWIN_ID = System.getenv("CHANNEL_DARWIN_ID");
@@ -20,33 +19,8 @@ public class Constants {
             "401726025765093377" // acexcy
     );
 
-    static {
-        loadBotVersion();
-    }
-
-    private static void loadBotVersion() {
-        Properties properties = new Properties();
-        try (InputStream input = Constants.class.getResourceAsStream("/version.properties")) {
-            if (input == null) {
-                logger.error("version.properties not found");
-                BOT_VERSION = "unknown";
-                return;
-            }
-            properties.load(input);
-            BOT_VERSION = properties.getProperty("version", "unknown");
-            logger.info("Bot version loaded: {}", BOT_VERSION);
-        } catch (IOException e) {
-            logger.error("Failed to load bot version", e);
-            BOT_VERSION = "unknown";
-        }
-    }
-
     public static List<String> getOwnerUserIds() {
         return OWNER_USER_IDS;
-    }
-
-    public static String getBotVersion() {
-        return BOT_VERSION;
     }
 
     public static String getBotToken() {
@@ -72,4 +46,5 @@ public class Constants {
     public static String getDBPassword() {
         return System.getenv("DB_PASSWORD");
     }
+
 }

--- a/src/main/java/resources/version.properties
+++ b/src/main/java/resources/version.properties
@@ -1,1 +1,0 @@
-version=${project.version}


### PR DESCRIPTION
This was being logged in the terminal when mbot-re is run which could be useful but we are not using versioning like we should so we can remove this.